### PR TITLE
Fix: install gremlin python script engine

### DIFF
--- a/Dockerfile.janus
+++ b/Dockerfile.janus
@@ -1,7 +1,7 @@
 FROM openjdk:8-jdk
 MAINTAINER Markus Mayer <widemeadows@gmail.com>
 
-ARG version=0.1.1
+ARG version=0.2.0
 ARG hadoop=hadoop2
 
 RUN apt-get update && \

--- a/Dockerfile.janus
+++ b/Dockerfile.janus
@@ -19,4 +19,6 @@ COPY janusgraph/janusgraph.properties /workspace/janusgraph/janusgraph.propertie
 COPY janusgraph/empty-sample.groovy /workspace/janusgraph/scripts/empty-sample.groovy
 
 WORKDIR /workspace/janusgraph
+RUN bin/gremlin-server.sh -i org.apache.tinkerpop gremlin-python 3.2.6
+
 CMD ["/bin/bash", "-e", "/workspace/janusgraph/run.sh"]

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ For multiple graphs in Titan (and likely also JanusGraph), follow these links:
 
 ## Scylla/Cassandra and Elasticsearch
 
-As per [compatibility matrix](http://docs.janusgraph.org/latest/version-compat.html), the supported Cassandra version is 2.1 and the supported Elasticsearch version is 1.5.
-This repository uses [Scylla](http://www.scylladb.com/) instead of Cassandra, and according to the [Scylla Cassandra Compatibility](http://docs.scylladb.com/cassandra-compatibility/) matrix we find that Scylla 1.7.2 is a drop-in replacement for Cassandra 2.1.8. 
+As per [compatibility matrix](http://docs.janusgraph.org/latest/version-compat.html), the supported Cassandra version is 3.11 and the supported Elasticsearch version is 1.5.
+This repository uses [Scylla](http://www.scylladb.com/) instead of Cassandra, and according to the [Scylla Cassandra Compatibility](http://docs.scylladb.com/cassandra-compatibility/) matrix we find that Scylla 2.0 is a drop-in replacement for Cassandra 2.1.8.
 
 The latest commit using Cassandra in this repo is 39c537de03a1bb7a65138b535df1ff003e8c4ec6, if you are interested in that.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For multiple graphs in Titan (and likely also JanusGraph), follow these links:
 
 ## Scylla/Cassandra and Elasticsearch
 
-As per [compatibility matrix](http://docs.janusgraph.org/latest/version-compat.html), the supported Cassandra version is 3.11 and the supported Elasticsearch version is 1.5.
+As per [compatibility matrix](http://docs.janusgraph.org/latest/version-compat.html), the supported Cassandra version is 3.11 and the supported Elasticsearch version is 5.
 This repository uses [Scylla](http://www.scylladb.com/) instead of Cassandra, and according to the [Scylla Cassandra Compatibility](http://docs.scylladb.com/cassandra-compatibility/) matrix we find that Scylla 2.0 is a drop-in replacement for Cassandra 2.1.8.
 
 The latest commit using Cassandra in this repo is 39c537de03a1bb7a65138b535df1ff003e8c4ec6, if you are interested in that.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - db
       - index
   db:
-    image: scylladb/scylla:1.7.2
+    image: scylladb/scylla:2.0.1
     ports:
      # http://docs.scylladb.com/kb/posix/
      # REST API

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,11 @@ version: '3'
 
 services:
   janus:
-    image: janusgraph:1.0.0-hadoop2
+    image: janusgraph:0.2.0-hadoop2
     build:
       dockerfile: Dockerfile.janus
       args:
-        version: 0.1.1
+        version: 0.2.0
         hadoop: hadoop2
       context: ./
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     volumes:
      - ./data/scylla/data:/var/lib/scylla
   index:
-    image: elasticsearch:1.5
+    image: elasticsearch:5
     ports:
      - "9200:9200"
      - "9300:9300"

--- a/janusgraph/gremlin-server.yaml
+++ b/janusgraph/gremlin-server.yaml
@@ -14,7 +14,8 @@ scriptEngines: {
   gremlin-groovy: {
     imports: [java.lang.Math],
     staticImports: [java.lang.Math.PI],
-    scripts: [scripts/empty-sample.groovy]}}
+    scripts: [scripts/empty-sample.groovy]},
+  gremlin-python: {}}
 serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { useMapperFromGraph: graph }}
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}

--- a/janusgraph/janusgraph.properties
+++ b/janusgraph/janusgraph.properties
@@ -3,7 +3,7 @@ gremlin.graph=org.janusgraph.core.JanusGraphFactory
 storage.backend=cassandra
 storage.hostname=db
 
-index.search.elasticsearch.interface=NODE
+index.search.elasticsearch.interface=REST_CLIENT
 index.search.backend=elasticsearch
 index.search.hostname=index
 

--- a/python-test/requirements.txt
+++ b/python-test/requirements.txt
@@ -1,2 +1,2 @@
-aiogremlin==3.2.5
-gremlinpython==3.2.5
+aiogremlin==3.2.*
+gremlinpython==3.2.*


### PR DESCRIPTION
The gremlin-python script engine for the Gremlin server is not installed.
It makes the connection to the Gremlin server using Python impossible.

See https://stackoverflow.com/a/46082468/833543 .